### PR TITLE
Allow v2 and v3 of doctrine for PHP 8 compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^7.4|^8.0",
         "illuminate/contracts": "^8.0",
-        "doctrine/dbal": "^3.0"
+        "doctrine/dbal": "~2.12|^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",


### PR DESCRIPTION
Release `1.1.1` added PHP 8 support but also added the minimum requirement for `^3.0` of `doctrine/dbal` due to compatibility issues.

Unfortunately, `laravel/nova` has PHP 8 support but does not yet support v3 of `doctrine/dbal`  (https://github.com/laravel/nova-issues/issues/3088) and is some time away from that being changed. 

This is currently my road block to upgrading to PHP 8. 

`v2.12.0` of `doctrine/dbal` added support for PHP 8. I changed this packages requirement to:

```json
doctrine/dbal: "~2.12|^3.0"
```

 I hope you are willing to accept this change so I can continue upgrading to PHP 8 🥳 