### PR TITLE
Avoid serializing `CleanConfig` object inside `stopWhen` parameter

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,4 +23,8 @@
     <logging>
         <junit outputFile="build/report.junit.xml"/>
     </logging>
+    <php>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+    </php>
 </phpunit>

--- a/src/CleanConfig.php
+++ b/src/CleanConfig.php
@@ -57,8 +57,8 @@ class CleanConfig
         $this->lockName = $this->convertQueryToLockName($query);
 
         if ($this->stopWhen === null) {
-            $this->stopWhen(function (CleanConfig $cleanConfig) use ($chunkSize) {
-                return $cleanConfig->rowsDeletedInThisPass < $chunkSize;
+            $this->stopWhen(function (CleanConfig $cleanConfig) {
+                return $cleanConfig->rowsDeletedInThisPass < $cleanConfig->deleteChunkSize;
             });
         }
     }

--- a/src/CleanConfig.php
+++ b/src/CleanConfig.php
@@ -57,8 +57,8 @@ class CleanConfig
         $this->lockName = $this->convertQueryToLockName($query);
 
         if ($this->stopWhen === null) {
-            $this->stopWhen(function (CleanConfig $cleanConfig) {
-                return $cleanConfig->rowsDeletedInThisPass < $this->deleteChunkSize;
+            $this->stopWhen(function (CleanConfig $cleanConfig) use ($chunkSize) {
+                return $cleanConfig->rowsDeletedInThisPass < $chunkSize;
             });
         }
     }


### PR DESCRIPTION
Without this change whole `CleanConfig` object gets serialized because of `$this` usage.

Here is an example of how `CleanConfig` object looked before this change. Notice serialization of itself inside `stopWhen` parameter.
<img width="1109" alt="image" src="https://github.com/spatie/laravel-queued-db-cleanup/assets/17316322/21c1a1f1-e5f4-4f35-ba36-25b82357e6b9">


Here is the object after change.
<img width="1105" alt="image" src="https://github.com/spatie/laravel-queued-db-cleanup/assets/17316322/b282bd1c-2814-48b7-818e-8bda0160648f">
