### PR TITLE
Support for database query builder

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,4 +23,8 @@
     <logging>
         <junit outputFile="build/report.junit.xml"/>
     </logging>
+    <php>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+    </php>
 </phpunit>

--- a/src/CleanConfig.php
+++ b/src/CleanConfig.php
@@ -48,7 +48,11 @@ class CleanConfig
      */
     public function usingQuery($query, int $chunkSize)
     {
-        $this->sql = $query->limit($chunkSize)->getGrammar()->compileDelete($query->toBase());
+        $baseQuery = $query instanceof \Illuminate\Database\Eloquent\Builder
+            ? $query->toBase()
+            : $query;
+
+        $this->sql = $query->limit($chunkSize)->getGrammar()->compileDelete($baseQuery);
 
         $this->sqlBindings = $query->getBindings();
 

--- a/tests/CleansUpDatabaseTest.php
+++ b/tests/CleansUpDatabaseTest.php
@@ -107,7 +107,7 @@ class CleansUpDatabaseTest extends TestCase
     public function it_accepts_database_query_builder()
     {
         CleanDatabaseJobFactory::new()
-            ->query(DB::query())
+            ->query(DB::table('test_models'))
             ->deleteChunkSize(10)
             ->dispatch();
 

--- a/tests/CleansUpDatabaseTest.php
+++ b/tests/CleansUpDatabaseTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LaravelQueuedDbCleanup\Tests;
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Spatie\LaravelQueuedDbCleanup\CleanConfig;
 use Spatie\LaravelQueuedDbCleanup\CleanDatabaseJobFactory;
@@ -92,6 +93,21 @@ class CleansUpDatabaseTest extends TestCase
     {
         CleanDatabaseJobFactory::new()
             ->query(TestModel::query())
+            ->deleteChunkSize(10)
+            ->dispatch();
+
+        Event::assertDispatched(function (CleanDatabasePassStarting $event) {
+            $this->assertSame(1, $event->cleanConfig->pass);
+
+            return true;
+        });
+    }
+
+    /** @test */
+    public function it_accepts_database_query_builder()
+    {
+        CleanDatabaseJobFactory::new()
+            ->query(DB::query())
             ->deleteChunkSize(10)
             ->dispatch();
 


### PR DESCRIPTION
Right now phpdocs suggest that both `CleanDatabaseJobFactory::query()` and `CleanConfig::usingQuery()` methods accept both eloquent and database query builders:
```php
/**
 * @param  \Illuminate\Database\Query\Builder|\Illuminate\Database\Eloquent\Builder  $query
 */
```
Turns out that passing in `\Illuminate\Database\Query\Builder` results in a crash because line [51 of `CleanConfig` class calls `$query->toBase()`](https://github.com/spatie/laravel-queued-db-cleanup/blob/5cba00f74dbb40075d8a74539f3c14315fa980ed/src/CleanConfig.php#L51) which is only available on eloquent query builder. Code throws `BadMethodCallException` with message `Call to undefined method Illuminate\Database\Query\Builder::toBase()`

This PR includes only a failing test to indicate this issue.

A potential solution would be to check if `$query` is already of type `\Illuminate\Database\Query\Builder` and then skip `$query->toBase()` call.
