### PR TITLE
Fix limit not being applied to query

### DIFF
--- a/src/CleanConfig.php
+++ b/src/CleanConfig.php
@@ -52,13 +52,13 @@ class CleanConfig
             ? $query->toBase()
             : $query;
 
-        $this->sql = $query->limit($chunkSize)->getGrammar()->compileDelete($baseQuery);
+        $this->sql = $baseQuery->limit($chunkSize)->getGrammar()->compileDelete($baseQuery);
 
-        $this->sqlBindings = $query->getBindings();
+        $this->sqlBindings = $baseQuery->getBindings();
 
         $this->deleteChunkSize = $chunkSize;
 
-        $this->lockName = $this->convertQueryToLockName($query);
+        $this->lockName = $this->convertQueryToLockName($baseQuery);
 
         if ($this->stopWhen === null) {
             $this->stopWhen(function (CleanConfig $cleanConfig) {


### PR DESCRIPTION
Broken by https://github.com/spatie/laravel-queued-db-cleanup/pull/17

The above change broke the following test in our application which picked up that the `deleteChunkSize` is no longer being applied to the `delete` query:

```diff
1) Tests\Unit\Models\AddressTest::testCleanFactory
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'delete from `addresses` where `updated_at` <= ? and `addresses`.`type` = ? limit 1000'
+'delete from `addresses` where `updated_at` <= ? and `addresses`.`type` = ?'
```

This PR ensures that the new variable defined in #17 is used everywhere else in the function which fixes the above issue. 